### PR TITLE
Allow unregistration of metrics

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -45,3 +45,22 @@ func WritePrometheus(w io.Writer, exposeProcessMetrics bool) {
 		writeProcessMetrics(w)
 	}
 }
+
+// WritePrometheusMetricSet will write all metrics registered in the provided set in Prometheus format to w.
+//
+// If exposeProcessMetrics is true, then various `go_*` and `process_*` metrics
+// are exposed for the current process.
+//
+// The WritePrometheusMetricSet func is usually called inside "/metrics" handler:
+//
+//     http.HandleFunc("/metrics", func(w http.ResponseWriter, req *http.Request) {
+//         metrics.WritePrometheusSet(set, w, true)
+//     })
+//
+func WritePrometheusMetricSet(set *Set, w io.Writer, exposeProcessMetrics bool) {
+	set.WritePrometheus(w)
+	if exposeProcessMetrics {
+		writeGoMetrics(w)
+		writeProcessMetrics(w)
+	}
+}

--- a/metrics.go
+++ b/metrics.go
@@ -41,26 +41,24 @@ var defaultSet = NewSet()
 func WritePrometheus(w io.Writer, exposeProcessMetrics bool) {
 	defaultSet.WritePrometheus(w)
 	if exposeProcessMetrics {
-		writeGoMetrics(w)
-		writeProcessMetrics(w)
+		WriteProcessMetrics(w)
 	}
 }
 
-// WritePrometheusMetricSet will write all metrics registered in the provided set in Prometheus format to w.
+// WriteProcessMetrics writes additional process metrics in Prometheus format to w.
 //
-// If exposeProcessMetrics is true, then various `go_*` and `process_*` metrics
-// are exposed for the current process.
+// Various `go_*` and `process_*` metrics are exposed for the currently
+// running process.
 //
-// The WritePrometheusMetricSet func is usually called inside "/metrics" handler:
+// The WriteProcessMetrics func is usually called in combination with writing Set metrics
+// inside "/metrics" handler:
 //
 //     http.HandleFunc("/metrics", func(w http.ResponseWriter, req *http.Request) {
-//         metrics.WritePrometheusSet(set, w, true)
+//         mySet.WritePrometheus(w)
+//         metrics.WriteProcessMetrics(w)
 //     })
 //
-func WritePrometheusMetricSet(set *Set, w io.Writer, exposeProcessMetrics bool) {
-	set.WritePrometheus(w)
-	if exposeProcessMetrics {
-		writeGoMetrics(w)
-		writeProcessMetrics(w)
-	}
+func WriteProcessMetrics(w io.Writer) {
+	writeGoMetrics(w)
+	writeProcessMetrics(w)
 }

--- a/set.go
+++ b/set.go
@@ -440,10 +440,7 @@ func (s *Set) registerMetric(name string, m metric) {
 }
 
 // UnregisterMetric will remove a registered metric
-func (s *Set) UnregisterMetric(name string) {
-	if err := validateMetric(name); err != nil {
-		panic(fmt.Errorf("BUG: invalid metric name %q: %s", name, err))
-	}
+func (s *Set) UnregisterMetric(name string) bool {
 	s.mu.Lock()
 	nm, ok := s.m[name]
 	if ok {
@@ -454,13 +451,6 @@ func (s *Set) UnregisterMetric(name string) {
 			}
 		}
 	}
-	s.mu.Unlock()
-}
-
-// HasMetric will return true, if the metric exists
-func (s *Set) HasMetric(name string) bool {
-	s.mu.Lock()
-	_, ok := s.m[name]
 	s.mu.Unlock()
 	return ok
 }

--- a/set.go
+++ b/set.go
@@ -438,3 +438,38 @@ func (s *Set) registerMetric(name string, m metric) {
 		panic(fmt.Errorf("BUG: metric %q is already registered", name))
 	}
 }
+
+// UnregisterMetric will remove a registered metric
+func (s *Set) UnregisterMetric(name string) {
+	if err := validateMetric(name); err != nil {
+		panic(fmt.Errorf("BUG: invalid metric name %q: %s", name, err))
+	}
+	s.mu.Lock()
+	nm, ok := s.m[name]
+	if ok {
+		delete(s.m, name)
+		for i, a := range s.a {
+			if a == nm {
+				s.a = append(s.a[:i], s.a[i+1:]...)
+			}
+		}
+	}
+	s.mu.Unlock()
+}
+
+// HasMetric will return true, if the metric exists
+func (s *Set) HasMetric(name string) bool {
+	s.mu.Lock()
+	_, ok := s.m[name]
+	s.mu.Unlock()
+	return ok
+}
+
+// ListMetricNames will return a list of all registered metrics
+func (s *Set) ListMetricNames() []string {
+	var list []string
+	for name := range s.m {
+		list = append(list, name)
+	}
+	return list
+}

--- a/set_test.go
+++ b/set_test.go
@@ -34,3 +34,55 @@ func TestNewSet(t *testing.T) {
 		}
 	}
 }
+
+func TestListMetricNames(t *testing.T) {
+	s := NewSet()
+	expect := []string{"cnt1", "cnt2", "cnt3"}
+	// Initialize a few counters
+	for _, n := range expect {
+		c := s.NewCounter(n)
+		c.Inc()
+	}
+
+	list := s.ListMetricNames()
+
+	if len(list) != len(expect) {
+		t.Fatalf("Metrics count is wrong for listing")
+	}
+	for _, e := range expect {
+		found := false
+		for _, n := range list {
+			if e == n {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("Metric %s not found in listing", e)
+		}
+	}
+}
+
+func TestUnregisterMetric(t *testing.T) {
+	s := NewSet()
+	// Initialize a few counters
+	for i := 0; i < 5; i++ {
+		c := s.NewCounter(fmt.Sprintf("counter_%d", i))
+		c.Inc()
+	}
+	if !s.HasMetric("counter_1") {
+		t.Fatalf("Metric counter_1 should be registered")
+	}
+	if !s.HasMetric("counter_3") {
+		t.Fatalf("Metric counter_1 should be registered")
+	}
+	// Remove counters
+	s.UnregisterMetric("counter_1")
+	s.UnregisterMetric("counter_3")
+	// Validate counters are removed
+	if s.HasMetric("counter_1") {
+		t.Fatalf("Metric counter_1 should be deregistered")
+	}
+	if s.HasMetric("counter_3") {
+		t.Fatalf("Metric counter_3 should be deregistered")
+	}
+}

--- a/set_test.go
+++ b/set_test.go
@@ -69,20 +69,26 @@ func TestUnregisterMetric(t *testing.T) {
 		c := s.NewCounter(fmt.Sprintf("counter_%d", i))
 		c.Inc()
 	}
-	if !s.HasMetric("counter_1") {
-		t.Fatalf("Metric counter_1 should be registered")
+	// Unregister existing counters
+	ok := s.UnregisterMetric("counter_1")
+	if !ok {
+		t.Fatalf("Metric counter_1 should return true for deregistering")
 	}
-	if !s.HasMetric("counter_3") {
-		t.Fatalf("Metric counter_1 should be registered")
+
+	// Unregister twice must return false
+	ok = s.UnregisterMetric("counter_1")
+	if ok {
+		t.Fatalf("Metric counter_1 should not return false on unregister twice")
 	}
-	// Remove counters
-	s.UnregisterMetric("counter_1")
-	s.UnregisterMetric("counter_3")
+
 	// Validate counters are removed
-	if s.HasMetric("counter_1") {
-		t.Fatalf("Metric counter_1 should be deregistered")
+	ok = false
+	for _, n := range s.ListMetricNames() {
+		if n == "counter_1" {
+			ok = true
+		}
 	}
-	if s.HasMetric("counter_3") {
-		t.Fatalf("Metric counter_3 should be deregistered")
+	if ok {
+		t.Fatalf("Metric counter_1 and counter_3 must not be listed anymore after unregister")
 	}
 }


### PR DESCRIPTION
For an exporter we implemented backend services are queried (via http) and metrics registered for those on the fly. As it can happen, that the backend is no longer available, we need a way to not return any metrics for this backend.

This PR will enhance metrics.Set to allow to list and unregister metrics. This will be mostly useful for prometheus/victoria exporters or applications with varying set of metrics.

Minimal tests are added and a new helper metrics.WritePrometheusMetricsSet to allow return only metrics defined in this specific set alongside with the default go/proc metrics.

Comments are very welcome.