### PR TITLE
summary: fix Unregister behaviour for summary metric type

### DIFF
--- a/summary.go
+++ b/summary.go
@@ -203,7 +203,7 @@ func addTag(name, tag string) string {
 	return fmt.Sprintf("%s,%s}", name[:len(name)-1], tag)
 }
 
-func registerSummary(sm *Summary) {
+func registerSummaryLocked(sm *Summary) {
 	window := sm.window
 	summariesLock.Lock()
 	summaries[window] = append(summaries[window], sm)


### PR DESCRIPTION
The change covers two things:
1. Cleanup of Set.a metrics list from per-quantile metrics
for summary.
2. Register summary metric and per-quantile metrics in one take.
This prevents registry corruption when Unregister called in the
middle of metric register process.