### PR TITLE
add optional types to metrics

### DIFF
--- a/counter.go
+++ b/counter.go
@@ -53,7 +53,10 @@ func (c *Counter) Set(n uint64) {
 }
 
 // marshalTo marshals c with the given prefix to w.
-func (c *Counter) marshalTo(prefix string, w io.Writer) {
+func (c *Counter) marshalTo(prefix string, w io.Writer, writeType bool) {
+	if writeType {
+		writeTypeTo(prefix, counterType, w)
+	}
 	v := c.Get()
 	fmt.Fprintf(w, "%s %d\n", prefix, v)
 }

--- a/floatcounter.go
+++ b/floatcounter.go
@@ -58,7 +58,10 @@ func (fc *FloatCounter) Set(n float64) {
 }
 
 // marshalTo marshals fc with the given prefix to w.
-func (fc *FloatCounter) marshalTo(prefix string, w io.Writer) {
+func (fc *FloatCounter) marshalTo(prefix string, w io.Writer, writeType bool) {
+	if writeType {
+		writeTypeTo(prefix, counterType, w)
+	}
 	v := fc.Get()
 	fmt.Fprintf(w, "%s %g\n", prefix, v)
 }

--- a/gauge.go
+++ b/gauge.go
@@ -36,7 +36,10 @@ func (g *Gauge) Get() float64 {
 	return g.f()
 }
 
-func (g *Gauge) marshalTo(prefix string, w io.Writer) {
+func (g *Gauge) marshalTo(prefix string, w io.Writer, writeType bool) {
+	if writeType {
+		writeTypeTo(prefix, gaugeType, w)
+	}
 	v := g.f()
 	if float64(int64(v)) == v {
 		// Marshal integer values without scientific notation

--- a/go_metrics.go
+++ b/go_metrics.go
@@ -8,35 +8,66 @@ import (
 	"github.com/valyala/histogram"
 )
 
-func writeGoMetrics(w io.Writer) {
+func writeGoMetrics(w io.Writer, writeType bool) {
+	t := func(name string, t metricType) {
+		if writeType {
+			writeTypeTo(name, t, w)
+		}
+	}
+
 	var ms runtime.MemStats
 	runtime.ReadMemStats(&ms)
+	t("go_memstats_alloc_bytes", gaugeType)
 	fmt.Fprintf(w, "go_memstats_alloc_bytes %d\n", ms.Alloc)
+	t("go_memstats_alloc_bytes_total", gaugeType)
 	fmt.Fprintf(w, "go_memstats_alloc_bytes_total %d\n", ms.TotalAlloc)
+	t("go_memstats_buck_hash_sys_bytes", gaugeType)
 	fmt.Fprintf(w, "go_memstats_buck_hash_sys_bytes %d\n", ms.BuckHashSys)
+	t("go_memstats_frees_total", counterType)
 	fmt.Fprintf(w, "go_memstats_frees_total %d\n", ms.Frees)
+	t("go_memstats_gc_cpu_fraction", gaugeType)
 	fmt.Fprintf(w, "go_memstats_gc_cpu_fraction %g\n", ms.GCCPUFraction)
+	t("go_memstats_gc_sys_bytes", gaugeType)
 	fmt.Fprintf(w, "go_memstats_gc_sys_bytes %d\n", ms.GCSys)
+	t("go_memstats_heap_alloc_bytes", gaugeType)
 	fmt.Fprintf(w, "go_memstats_heap_alloc_bytes %d\n", ms.HeapAlloc)
+	t("go_memstats_heap_idle_bytes", gaugeType)
 	fmt.Fprintf(w, "go_memstats_heap_idle_bytes %d\n", ms.HeapIdle)
+	t("go_memstats_heap_inuse_bytes", gaugeType)
 	fmt.Fprintf(w, "go_memstats_heap_inuse_bytes %d\n", ms.HeapInuse)
+	t("go_memstats_heap_objects", gaugeType)
 	fmt.Fprintf(w, "go_memstats_heap_objects %d\n", ms.HeapObjects)
+	t("go_memstats_heap_released_bytes", counterType)
 	fmt.Fprintf(w, "go_memstats_heap_released_bytes %d\n", ms.HeapReleased)
+	t("go_memstats_heap_sys_bytes", gaugeType)
 	fmt.Fprintf(w, "go_memstats_heap_sys_bytes %d\n", ms.HeapSys)
+	t("go_memstats_last_gc_time_seconds", gaugeType)
 	fmt.Fprintf(w, "go_memstats_last_gc_time_seconds %g\n", float64(ms.LastGC)/1e9)
+	t("go_memstats_lookups_total", counterType)
 	fmt.Fprintf(w, "go_memstats_lookups_total %d\n", ms.Lookups)
+	t("go_memstats_mallocs_total", counterType)
 	fmt.Fprintf(w, "go_memstats_mallocs_total %d\n", ms.Mallocs)
+	t("go_memstats_mcache_inuse_bytes", gaugeType)
 	fmt.Fprintf(w, "go_memstats_mcache_inuse_bytes %d\n", ms.MCacheInuse)
+	t("go_memstats_mcache_sys_bytes", gaugeType)
 	fmt.Fprintf(w, "go_memstats_mcache_sys_bytes %d\n", ms.MCacheSys)
+	t("go_memstats_mspan_inuse_bytes", gaugeType)
 	fmt.Fprintf(w, "go_memstats_mspan_inuse_bytes %d\n", ms.MSpanInuse)
+	t("go_memstats_mspan_sys_bytes", gaugeType)
 	fmt.Fprintf(w, "go_memstats_mspan_sys_bytes %d\n", ms.MSpanSys)
+	t("go_memstats_next_gc_bytes", gaugeType)
 	fmt.Fprintf(w, "go_memstats_next_gc_bytes %d\n", ms.NextGC)
+	t("go_memstats_other_sys_bytes", gaugeType)
 	fmt.Fprintf(w, "go_memstats_other_sys_bytes %d\n", ms.OtherSys)
+	t("go_memstats_stack_inuse_bytes", gaugeType)
 	fmt.Fprintf(w, "go_memstats_stack_inuse_bytes %d\n", ms.StackInuse)
+	t("go_memstats_stack_sys_bytes", gaugeType)
 	fmt.Fprintf(w, "go_memstats_stack_sys_bytes %d\n", ms.StackSys)
+	t("go_memstats_sys_bytes", gaugeType)
 	fmt.Fprintf(w, "go_memstats_sys_bytes %d\n", ms.Sys)
-
+	t("go_cgo_calls_count", counterType)
 	fmt.Fprintf(w, "go_cgo_calls_count %d\n", runtime.NumCgoCall())
+	t("go_cpu_count", gaugeType)
 	fmt.Fprintf(w, "go_cpu_count %d\n", runtime.NumCPU())
 
 	gcPauses := histogram.NewFast()
@@ -45,20 +76,29 @@ func writeGoMetrics(w io.Writer) {
 	}
 	phis := []float64{0, 0.25, 0.5, 0.75, 1}
 	quantiles := make([]float64, 0, len(phis))
+	t("go_gc_duration_seconds", summaryType)
 	for i, q := range gcPauses.Quantiles(quantiles[:0], phis) {
 		fmt.Fprintf(w, `go_gc_duration_seconds{quantile="%g"} %g`+"\n", phis[i], q)
 	}
+	t("go_gc_duration_seconds_sum", gaugeType)
 	fmt.Fprintf(w, `go_gc_duration_seconds_sum %g`+"\n", float64(ms.PauseTotalNs)/1e9)
+	t("go_gc_duration_seconds_count", counterType)
 	fmt.Fprintf(w, `go_gc_duration_seconds_count %d`+"\n", ms.NumGC)
+	t("go_gc_forced_count", counterType)
 	fmt.Fprintf(w, `go_gc_forced_count %d`+"\n", ms.NumForcedGC)
 
+	t("go_gomaxprocs", gaugeType)
 	fmt.Fprintf(w, `go_gomaxprocs %d`+"\n", runtime.GOMAXPROCS(0))
+	t("go_goroutines", gaugeType)
 	fmt.Fprintf(w, `go_goroutines %d`+"\n", runtime.NumGoroutine())
 	numThread, _ := runtime.ThreadCreateProfile(nil)
+	t("go_threads", gaugeType)
 	fmt.Fprintf(w, `go_threads %d`+"\n", numThread)
 
 	// Export build details.
+	t("go_info", untypedType)
 	fmt.Fprintf(w, "go_info{version=%q} 1\n", runtime.Version())
+	t("go_info_ext", untypedType)
 	fmt.Fprintf(w, "go_info_ext{compiler=%q, GOARCH=%q, GOOS=%q, GOROOT=%q} 1\n",
 		runtime.Compiler, runtime.GOARCH, runtime.GOOS, runtime.GOROOT())
 }

--- a/histogram.go
+++ b/histogram.go
@@ -233,7 +233,10 @@ var (
 	bucketRangesOnce sync.Once
 )
 
-func (h *Histogram) marshalTo(prefix string, w io.Writer) {
+func (h *Histogram) marshalTo(prefix string, w io.Writer, writeType bool) {
+	if writeType {
+		writeTypeTo(prefix, histogramType, w)
+	}
 	countTotal := uint64(0)
 	h.VisitNonZeroBuckets(func(vmrange string, count uint64) {
 		tag := fmt.Sprintf("vmrange=%q", vmrange)

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -138,7 +138,7 @@ func testConcurrent(f func() error) error {
 func testMarshalTo(t *testing.T, m metric, prefix, resultExpected string) {
 	t.Helper()
 	var bb bytes.Buffer
-	m.marshalTo(prefix, &bb)
+	m.marshalTo(prefix, &bb, false)
 	result := bb.String()
 	if result != resultExpected {
 		t.Fatalf("unexpected marshaled metric;\ngot\n%q\nwant\n%q", result, resultExpected)

--- a/process_metrics_other.go
+++ b/process_metrics_other.go
@@ -6,6 +6,6 @@ import (
 	"io"
 )
 
-func writeProcessMetrics(w io.Writer) {
+func writeProcessMetrics(w io.Writer, writeType bool) {
 	// TODO: implement it
 }

--- a/set.go
+++ b/set.go
@@ -30,6 +30,16 @@ func NewSet() *Set {
 
 // WritePrometheus writes all the metrics from s to w in Prometheus format.
 func (s *Set) WritePrometheus(w io.Writer) {
+	s.writePrometheus(w, false)
+}
+
+// WritePrometheusTyped writes all the metrics from s to w in Prometheus format
+// with types.
+func (s *Set) WritePrometheusTyped(w io.Writer) {
+	s.writePrometheus(w, true)
+}
+
+func (s *Set) writePrometheus(w io.Writer, writeTypes bool) {
 	// Collect all the metrics in in-memory buffer in order to prevent from long locking due to slow w.
 	var bb bytes.Buffer
 	lessFunc := func(i, j int) bool {
@@ -48,7 +58,7 @@ func (s *Set) WritePrometheus(w io.Writer) {
 	// Call marshalTo without the global lock, since certain metric types such as Gauge
 	// can call a callback, which, in turn, can try calling s.mu.Lock again.
 	for _, nm := range sa {
-		nm.metric.marshalTo(nm.name, &bb)
+		nm.metric.marshalTo(nm.name, &bb, writeTypes)
 	}
 	w.Write(bb.Bytes())
 }

--- a/summary.go
+++ b/summary.go
@@ -98,7 +98,11 @@ func (sm *Summary) UpdateDuration(startTime time.Time) {
 	sm.Update(d)
 }
 
-func (sm *Summary) marshalTo(prefix string, w io.Writer) {
+func (sm *Summary) marshalTo(prefix string, w io.Writer, writeType bool) {
+	if writeType {
+		writeTypeTo(prefix, summaryType, w)
+	}
+
 	// Marshal only *_sum and *_count values.
 	// Quantile values should be already updated by the caller via sm.updateQuantiles() call.
 	// sm.quantileValues will be marshaled later via quantileValue.marshalTo.
@@ -187,7 +191,7 @@ type quantileValue struct {
 	idx int
 }
 
-func (qv *quantileValue) marshalTo(prefix string, w io.Writer) {
+func (qv *quantileValue) marshalTo(prefix string, w io.Writer, writeType bool) {
 	qv.sm.mu.Lock()
 	v := qv.sm.quantileValues[qv.idx]
 	qv.sm.mu.Unlock()


### PR DESCRIPTION
The new prometheus format has types. Some scrapers (like datadog agent)
use the types to map from prometheus types to types in their service.

This is the spec which includes information about types here.
https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md

This are the datadog docs which show how the types are mapped. This
shows that there's a major use-case for types.
https://docs.datadoghq.com/integrations/guide/prometheus-metrics/

The approach to add type support was to add additional versions of
exported functions that write types. This is an additive change which
does not break the package API.

TODO(sbunce): There are no unit tests in this change yet. I'm looking for feedback
on if people are alright with adding these types and the approach. If people are
generally happy, then I will spend the time making tests. :)