### PR TITLE
fix example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ exposed from your application.
 #### How to implement [CounterVec](https://godoc.org/github.com/prometheus/client_golang/prometheus#CounterVec) in `metrics`?
 
 Just use [GetOrCreateCounter](http://godoc.org/github.com/VictoriaMetrics/metrics#GetOrCreateCounter)
-instead of `CounterVec.With`. See [this example](https://godoc.org/github.com/VictoriaMetrics/metrics#example-Counter--Vec) for details.
+instead of `CounterVec.With`. See [this example](https://pkg.go.dev/github.com/VictoriaMetrics/metrics#example-Counter-Vec) for details.
 
 
 #### Why [Histogram](http://godoc.org/github.com/VictoriaMetrics/metrics#Histogram) buckets contain `vmrange` labels instead of `le` labels like in Prometheus histograms?


### PR DESCRIPTION
The link redirects to https://pkg.go.dev/github.com/VictoriaMetrics/metrics#example-Counter--Vec , which doesn't exist (note the double `--`: godoc has two slashes, pkg.go.dev only one).

It's maybe a bit weird to link to pkg.go.dev for only one link. I can switch them all over if you prefer. Or they could all go to https://godocs.io instead, which still uses the double `--`: https://godocs.io/github.com/VictoriaMetrics/metrics#example-Counter--Vec