### PR TITLE
Use Getpagesize replace hard-coded page size

### DIFF
--- a/process_metrics_linux.go
+++ b/process_metrics_linux.go
@@ -80,7 +80,7 @@ func writeProcessMetrics(w io.Writer) {
 	WriteCounterUint64(w, "process_major_pagefaults_total", uint64(p.Majflt))
 	WriteCounterUint64(w, "process_minor_pagefaults_total", uint64(p.Minflt))
 	WriteGaugeUint64(w, "process_num_threads", uint64(p.NumThreads))
-	WriteGaugeUint64(w, "process_resident_memory_bytes", uint64(p.Rss)*4096)
+	WriteGaugeUint64(w, "process_resident_memory_bytes", uint64(p.Rss)*uint64(os.Getpagesize()))
 	WriteGaugeUint64(w, "process_start_time_seconds", uint64(startTimeSeconds))
 	WriteGaugeUint64(w, "process_virtual_memory_bytes", uint64(p.Vsize))
 	writeProcessMemMetrics(w)


### PR DESCRIPTION
The `process_resident_memory_bytes`  use 4096 as hard-coded page sizes on all architectures, some of which are probably  not right. Use `os.Getpagesize()` instead. This could fix issue: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6457
