### PR TITLE
name composer: fast and slow (reflect-based) implementations

### DIFF
--- a/composer.go
+++ b/composer.go
@@ -1,0 +1,140 @@
+package metrics
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// LabelComposer lets you compose valid labels string
+// Implement this interface if your want fast labels generation
+// Otherwise it will fall back to a slow reflection-based implementation
+type LabelComposer interface {
+	ToLabelsString() string
+}
+
+// labelComposerMarker is a marker interface for enforcing type-safety of StructLabelComposer.
+// Interface is private so it's only be used via StructLabelComposer implementation.
+// This is made for safety reasons, so it's not allowed to pass a random struct to NameCompose() function.
+type labelComposerMarker interface {
+	labelComposerMarker()
+}
+
+// StructLabelComposer MUST be embedded in any struct that serves as a label composer.
+// Embedding is required even if you provide custom implementation of LabelComposer (ToLabelsString() method)
+type StructLabelComposer struct{}
+
+func (s StructLabelComposer) labelComposerMarker() { panic("should never happen") }
+
+// NameCompose returns a valid full metric name, composed of a metric name + stringified labels
+// It will first try to use custom LabelComposer implementation (if any)
+// then fallback to slow reflection-based implementation.
+//
+// The NameCompose can be called for further GetOrCreateCounter/etc func:
+//
+//	// `my_counter{status="active",flag="false"}`
+//	GetOrCreateCounter(NameCompose("my_counter", MyLabels{
+//	  Status: "active",
+//	  Flag:   false,
+//	})).Inc()
+func NameCompose(name string, lc labelComposerMarker) string {
+	if lc == nil {
+		return name
+	}
+
+	// Implementing public LabelComposer means we must implement
+	// a custom ToLabelsString() that supposed to be fast.
+	if v, ok := lc.(LabelComposer); ok {
+		return name + v.ToLabelsString()
+	}
+
+	// falling back to reflect-based implementation
+	// This is considered to be slow. Implement your own LabelComposer if it's an issue for you.
+	return name + reflectLabelCompose(lc)
+}
+
+// reflectLabelCompose composes labels string {field="value",...} from a struct
+// It will use only exported scalar fields, and will skip fields with the `-` tag.
+// By default, the snake_cased field name is used as the label name.
+// Label's name can be overridden by using the `labels` tag
+func reflectLabelCompose(lc labelComposerMarker) string {
+	labelsStr := "{"
+
+	val := reflect.Indirect(reflect.ValueOf(lc))
+	typ := val.Type()
+
+	var n int
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if field.Anonymous || !field.IsExported() {
+			continue
+		}
+		ft := field.Type
+		if field.Type.Kind() == reflect.Pointer {
+			ft = field.Type.Elem()
+		}
+		fk := ft.Kind()
+
+		// We only support basic scalar types: Strings, Numbers, Bool
+		if fk != reflect.String && fk != reflect.Bool && (fk < reflect.Int || fk > reflect.Uint64) {
+			continue
+		}
+
+		var labelName string
+		if ourTag := field.Tag.Get(labelsTag); ourTag != "" {
+			if ourTag == "-" { // tag="-" means "skip this field"
+				continue
+			}
+			labelName = ourTag
+		} else {
+			labelName = toSnakeCase(field.Name)
+		}
+
+		if n > 0 {
+			labelsStr += ","
+		}
+		labelsStr += labelName + `="` + stringifyLabelValue(val.Field(i)) + `"`
+		n++
+	}
+
+	return labelsStr + "}"
+}
+
+// labelsTag is the tag name used for labels inside structs.
+// The tag is optional, as if not present, field is used with snake_cased FieldName.
+// It's useful to use a tag when you want to override the default naming or exclude a field from the metric.
+var labelsTag = "labels"
+
+// SetLabelsStructTag sets the tag name used for labels inside structs.
+func SetLabelsStructTag(tag string) {
+	labelsTag = tag
+}
+
+// stringifyLabelValue makes up a valid string value from a given field's value
+// It's used ONLY in fallback reflect mode
+// Field value might be a pointer, that's why we do reflect.Indirect()
+// Note: in future we can handle default values here as well
+func stringifyLabelValue(v reflect.Value) string {
+	k := v.Kind()
+	if k == reflect.Ptr {
+		if v.IsNil() {
+			return "nil"
+		}
+		v = v.Elem()
+	}
+
+	return fmt.Sprintf("%v", v.Interface())
+}
+
+// Convert struct field names to snake_case for Prometheus label compliance.
+func toSnakeCase(s string) string {
+	s = strings.TrimSpace(s)
+	var result []rune
+	for i, r := range s {
+		if i > 0 && r >= 'A' && r <= 'Z' {
+			result = append(result, '_')
+		}
+		result = append(result, r)
+	}
+	return strings.ToLower(string(result))
+}

--- a/composer_test.go
+++ b/composer_test.go
@@ -5,34 +5,11 @@ import (
 	"testing"
 )
 
-// MyLabelsSlow will be converted into {hello="world",enabled="true"}
-// via reflect implementation.
-// It's slow but completely automatic. You don't need to write any code
-type MyLabelsSlow struct {
-	StructLabelComposer
-
-	Status string
-	Flag   bool
-}
-
-func TestLabelComposeWithReflect(t *testing.T) {
-	want := `my_counter{status="active",flag="true"}`
-
-	got := NameCompose("my_counter", MyLabelsSlow{
-		Status: "active",
-		Flag:   true,
-	})
-
-	if got != want {
-		t.Fatalf("unexpected full name; got %q; want %q", got, want)
-	}
-}
-
 // MyLabelsFast will be converted into string
 // via custom implementation (Using ToLabelsString() method of LabelComposer interface)
 // It's fast but requires manual implementation.
 type MyLabelsFast struct {
-	StructLabelComposer
+	AutoLabelComposer
 	Status string
 	Flag   bool
 }
@@ -40,7 +17,7 @@ type MyLabelsFast struct {
 func (m *MyLabelsFast) ToLabelsString() string {
 	return "{" +
 		`status="` + m.Status + `",` +
-		`flag="` + fmt.Sprintf("%v", m.Flag) + `"` +
+		`flag="` + fmt.Sprintf("%t", m.Flag) + `"` +
 		"}"
 }
 
@@ -51,6 +28,29 @@ func TestLabelComposeWithoutReflect(t *testing.T) {
 	})
 
 	if want != got {
+		t.Fatalf("unexpected full name; got %q; want %q", got, want)
+	}
+}
+
+func TestLabelComposeWithReflect(t *testing.T) {
+	want := `my_counter{status="active",flag="true"}`
+
+	// MyLabelsSlow will be converted into {hello="world",enabled="true"}
+	// via reflect implementation.
+	// It's slow but completely automatic. You don't need to write any code
+	type MyLabelsAuto struct {
+		AutoLabelComposer
+
+		Status string
+		Flag   bool
+	}
+
+	got := NameComposeAuto("my_counter", MyLabelsAuto{
+		Status: "active",
+		Flag:   true,
+	})
+
+	if got != want {
 		t.Fatalf("unexpected full name; got %q; want %q", got, want)
 	}
 }

--- a/composer_test.go
+++ b/composer_test.go
@@ -1,0 +1,56 @@
+package metrics
+
+import (
+	"fmt"
+	"testing"
+)
+
+// MyLabelsSlow will be converted into {hello="world",enabled="true"}
+// via reflect implementation.
+// It's slow but completely automatic. You don't need to write any code
+type MyLabelsSlow struct {
+	StructLabelComposer
+
+	Status string
+	Flag   bool
+}
+
+func TestLabelComposeWithReflect(t *testing.T) {
+	want := `my_counter{status="active",flag="true"}`
+
+	got := NameCompose("my_counter", MyLabelsSlow{
+		Status: "active",
+		Flag:   true,
+	})
+
+	if got != want {
+		t.Fatalf("unexpected full name; got %q; want %q", got, want)
+	}
+}
+
+// MyLabelsFast will be converted into string
+// via custom implementation (Using ToLabelsString() method of LabelComposer interface)
+// It's fast but requires manual implementation.
+type MyLabelsFast struct {
+	StructLabelComposer
+	Status string
+	Flag   bool
+}
+
+func (m *MyLabelsFast) ToLabelsString() string {
+	return "{" +
+		`status="` + m.Status + `",` +
+		`flag="` + fmt.Sprintf("%v", m.Flag) + `"` +
+		"}"
+}
+
+func TestLabelComposeWithoutReflect(t *testing.T) {
+	want := `my_counter{status="active",flag="true"}`
+	got := NameCompose("my_counter", &MyLabelsFast{
+		Status: "active", Flag: true,
+	})
+
+	if want != got {
+		t.Fatalf("unexpected full name; got %q; want %q", got, want)
+	}
+}


### PR DESCRIPTION
### Context && Motivation

To create a new metric we have to manually write the full metric name (+ stringified labels) e.g. `foo{bar="baz",aaa="b"}` That can be tricky and overwhelming when doing it manually: raw strings always give a chance to make a typo (invalid syntax, wrong name, wrong type, missing/extra labels, etc)

### Solution
Provide a helper function "NameCompose" that will let us to compose full metric name with given metric_name and labels. To avoid using raw maps (that still can lead to typos and issues explained above), let's do the type-safe solution, using structs. 

Two possible solutions are available here:

#### 1. Fast solution (but manual declaring helper for each labels set)

```go
type MyLabelsSet struct {
   Foo string
   Bar int
   Flag bool
}

func (s MyLabelsSet) ToLabelsString() string {
  return `{foo="`+s.Foo+`",bar="`+fmt.Sprintf("%d", s.Bar)+`",flag="`+fmt.Sprintf("%t", s.Flag)+`"}`
}

GetOrCreateCounter(NameCompose("my_counter", MyLabelsSet{
  Foo: "foo1", Bar: 3, Flag: true
 }).Inc()
// -> my_counter{foo:"foo1",bar:"3",flag:"true"}
```

#### 2. Auto-compose solution (but slow, reflect is involved)

```go
// + No need to declare a custom method to a struct
// + Type can be defined on-the-fly inside a function

func SomeFunc() {
  type MyLabelsAuto struct {
    AutoLabelComposer // making this labels set to let it automatically generate labels string
    Foo string
    Bar int
    Flag bool
  }

  GetOrCreateCounter(NameComposeAuto("my_counter", MyLabelsAuto{
     Foo: "foo1", Bar: 3, Flag: true
  }).Inc()
  // -> my_counter{foo:"foo1",bar:"3",flag:"true"}
```


### Notes:
+ Reflect is involved but *optional*. You can always declare your own `ToLabelsString()` method to your labels struct and use it.
+ Reflect as a dependency by itself doesn't harm the "lightweight" factor of the library.


What do you think about such a feature?
