### PR TITLE
Forbid metrics with line breaks

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -10,6 +10,9 @@ func validateMetric(s string) error {
 	if len(s) == 0 {
 		return fmt.Errorf("metric cannot be empty")
 	}
+	if strings.IndexByte(s, '\n') != -1 {
+		return fmt.Errorf("metric cannot contain line breaks")
+	}
 	n := strings.IndexByte(s, '{')
 	if n < 0 {
 		return validateIdent(s)

--- a/validator.go
+++ b/validator.go
@@ -10,7 +10,7 @@ func validateMetric(s string) error {
 	if len(s) == 0 {
 		return fmt.Errorf("metric cannot be empty")
 	}
-	if strings.IndexByte(s, '\n') != -1 {
+	if strings.IndexByte(s, '\n') >= 0 {
 		return fmt.Errorf("metric cannot contain line breaks")
 	}
 	n := strings.IndexByte(s, '{')


### PR DESCRIPTION
# The Issue
Im using victoriametrics to monitor the usage of a sqlite database:
`store_sqlite_request_total{query="DELETE FROM 'Order'",status="success"} 2`
Though I had problem with particular queries being not present in victoriametrics. And It turns out that it was caused by me recording queries with not escaped line breaks.
Here is a fragment of the resulting /metrics endpoint:
```
store_sqlite_request_total{query="
  SELECT DISTINCT o.LocationId FROM \"Order\" o
    LEFT JOIN Location l ON o.LocationId = l.Id
    WHERE l.Id IS NULL
    AND o.LocationId >= 60000000 AND o.LocationId <= 64000000;
  ",status="success"} 2
store_sqlite_request_total{query="DELETE FROM `Order`",status="success"} 2
store_sqlite_request_total{query="INSERT OR REPLACE INTO History VALUES (?,?,?)",status="success"} 15300
```

# A Proposed Solution
Issue a warning or error when being handed a metrics with a line break. Im the PR I opted to simply error.