### PR TITLE
validator: expose ValidateMetric method

### DIFF
--- a/set.go
+++ b/set.go
@@ -105,7 +105,7 @@ func (s *Set) GetOrCreateHistogram(name string) *Histogram {
 	s.mu.Unlock()
 	if nm == nil {
 		// Slow path - create and register missing histogram.
-		if err := validateMetric(name); err != nil {
+		if err := ValidateMetric(name); err != nil {
 			panic(fmt.Errorf("BUG: invalid metric name %q: %s", name, err))
 		}
 		nmNew := &namedMetric{
@@ -163,7 +163,7 @@ func (s *Set) GetOrCreateCounter(name string) *Counter {
 	s.mu.Unlock()
 	if nm == nil {
 		// Slow path - create and register missing counter.
-		if err := validateMetric(name); err != nil {
+		if err := ValidateMetric(name); err != nil {
 			panic(fmt.Errorf("BUG: invalid metric name %q: %s", name, err))
 		}
 		nmNew := &namedMetric{
@@ -221,7 +221,7 @@ func (s *Set) GetOrCreateFloatCounter(name string) *FloatCounter {
 	s.mu.Unlock()
 	if nm == nil {
 		// Slow path - create and register missing counter.
-		if err := validateMetric(name); err != nil {
+		if err := ValidateMetric(name); err != nil {
 			panic(fmt.Errorf("BUG: invalid metric name %q: %s", name, err))
 		}
 		nmNew := &namedMetric{
@@ -284,7 +284,7 @@ func (s *Set) GetOrCreateGauge(name string, f func() float64) *Gauge {
 	s.mu.Unlock()
 	if nm == nil {
 		// Slow path - create and register missing gauge.
-		if err := validateMetric(name); err != nil {
+		if err := ValidateMetric(name); err != nil {
 			panic(fmt.Errorf("BUG: invalid metric name %q: %s", name, err))
 		}
 		nmNew := &namedMetric{
@@ -335,7 +335,7 @@ func (s *Set) NewSummary(name string) *Summary {
 //
 // The returned summary is safe to use from concurrent goroutines.
 func (s *Set) NewSummaryExt(name string, window time.Duration, quantiles []float64) *Summary {
-	if err := validateMetric(name); err != nil {
+	if err := ValidateMetric(name); err != nil {
 		panic(fmt.Errorf("BUG: invalid metric name %q: %s", name, err))
 	}
 	sm := newSummary(window, quantiles)
@@ -389,7 +389,7 @@ func (s *Set) GetOrCreateSummaryExt(name string, window time.Duration, quantiles
 	s.mu.Unlock()
 	if nm == nil {
 		// Slow path - create and register missing summary.
-		if err := validateMetric(name); err != nil {
+		if err := ValidateMetric(name); err != nil {
 			panic(fmt.Errorf("BUG: invalid metric name %q: %s", name, err))
 		}
 		sm := newSummary(window, quantiles)
@@ -434,7 +434,7 @@ func (s *Set) registerSummaryQuantilesLocked(name string, sm *Summary) {
 }
 
 func (s *Set) registerMetric(name string, m metric) {
-	if err := validateMetric(name); err != nil {
+	if err := ValidateMetric(name); err != nil {
 		panic(fmt.Errorf("BUG: invalid metric name %q: %s", name, err))
 	}
 	s.mu.Lock()

--- a/validator.go
+++ b/validator.go
@@ -6,7 +6,14 @@ import (
 	"strings"
 )
 
-func validateMetric(s string) error {
+// ValidateMetric validates provided string
+// to be valid Prometheus-compatible metric with possible labels.
+// For instance,
+//
+//   - foo
+//   - foo{bar="baz"}
+//   - foo{bar="baz",aaa="b"}
+func ValidateMetric(s string) error {
 	if len(s) == 0 {
 		return fmt.Errorf("metric cannot be empty")
 	}

--- a/validator_test.go
+++ b/validator_test.go
@@ -7,7 +7,7 @@ import (
 func TestValidateMetricSuccess(t *testing.T) {
 	f := func(s string) {
 		t.Helper()
-		if err := validateMetric(s); err != nil {
+		if err := ValidateMetric(s); err != nil {
 			t.Fatalf("cannot validate %q: %s", s, err)
 		}
 	}
@@ -24,7 +24,7 @@ func TestValidateMetricSuccess(t *testing.T) {
 func TestValidateMetricError(t *testing.T) {
 	f := func(s string) {
 		t.Helper()
-		if err := validateMetric(s); err == nil {
+		if err := ValidateMetric(s); err == nil {
 			t.Fatalf("expecting non-nil error when validating %q", s)
 		}
 	}


### PR DESCRIPTION
 It helps to check metric name syntax at runtime.
And validate dynamically created time series.