### PR TITLE
Add estimate `_sum` for go runtime histogram

### DIFF
--- a/go_metrics.go
+++ b/go_metrics.go
@@ -165,6 +165,7 @@ func writeRuntimeHistogramMetric(w io.Writer, name string, h *runtimemetrics.Flo
 
 	totalCount := uint64(0)
 	iNext := 0.0
+	sum := float64(0)
 	WriteMetadataIfNeeded(w, name, "histogram")
 	for i, count := range counts {
 		totalCount += count
@@ -175,9 +176,14 @@ func writeRuntimeHistogramMetric(w io.Writer, name string, h *runtimemetrics.Flo
 				fmt.Fprintf(w, `%s_bucket{le="%g"} %d`+"\n", name, le, totalCount)
 			}
 		}
+		if count != 0 {
+			sum += buckets[i] * float64(count)
+		}
 	}
 	totalCount += tailCount
 	fmt.Fprintf(w, `%s_bucket{le="+Inf"} %d`+"\n", name, totalCount)
+	fmt.Fprintf(w, `%s_sum %g`+"\n", name, sum)
+	fmt.Fprintf(w, `%s_count %d`+"\n", name, totalCount)
 }
 
 // Limit the number of buckets for Go runtime histograms in order to prevent from high cardinality issues at scraper side.

--- a/go_metrics_test.go
+++ b/go_metrics_test.go
@@ -35,6 +35,8 @@ func TestWriteRuntimeHistogramMetricOk(t *testing.T) {
 foo_bucket{le="3"} 3
 foo_bucket{le="4"} 6
 foo_bucket{le="+Inf"} 6
+foo_sum 14
+foo_count 6
 `)
 
 	f(&runtimemetrics.Float64Histogram{
@@ -44,6 +46,8 @@ foo_bucket{le="+Inf"} 6
 foo_bucket{le="3"} 25
 foo_bucket{le="4"} 26
 foo_bucket{le="+Inf"} 26
+foo_sum 53
+foo_count 26
 `)
 
 	f(&runtimemetrics.Float64Histogram{
@@ -59,6 +63,8 @@ foo_bucket{le="8"} 88
 foo_bucket{le="9"} 220
 foo_bucket{le="10"} 230
 foo_bucket{le="+Inf"} 230
+foo_sum 1580
+foo_count 230
 `)
 
 	f(&runtimemetrics.Float64Histogram{
@@ -67,5 +73,7 @@ foo_bucket{le="+Inf"} 230
 	}, `foo_bucket{le="4"} 1
 foo_bucket{le="5"} 6
 foo_bucket{le="+Inf"} 6
+foo_sum -Inf
+foo_count 6
 `)
 }


### PR DESCRIPTION
## Change

https://github.com/VictoriaMetrics/metrics/issues/94

This pull request adds estimate `_sum`, and accurate `_count` for go runtime histogram metrics.

The following metrics will be affected:
```
go_sched_latencies_seconds
go_gc_pauses_seconds
```