### PR TITLE
docs: Add comment for go histogram

### DIFF
--- a/go_metrics.go
+++ b/go_metrics.go
@@ -178,6 +178,13 @@ func writeRuntimeHistogramMetric(w io.Writer, name string, h *runtimemetrics.Flo
 	}
 	totalCount += tailCount
 	fmt.Fprintf(w, `%s_bucket{le="+Inf"} %d`+"\n", name, totalCount)
+	// There's no `_sum` for histogram, as go metrics only provided buckets and counter of each bucket.
+	// See: https://github.com/golang/go/blob/3432c68467d50ffc622fed230a37cd401d82d4bf/src/runtime/metrics/histogram.go#L8
+	//
+	// Prometheus SDK provides a (under)estimated `_sum` instead.
+	// See: https://github.com/prometheus/client_golang/blob/5fe1d33cea76068edd4ece5f58e52f81d225b13c/prometheus/go_collector_latest.go#L498
+	//
+	// Also, there's no need to provide a `_count` as it can be represented by the `+Inf` bucket.
 }
 
 // Limit the number of buckets for Go runtime histograms in order to prevent from high cardinality issues at scraper side.


### PR DESCRIPTION
Address https://github.com/VictoriaMetrics/metrics/issues/94.

The following comment is added to `go_metrics.go` to explain why `_sum` and `_count` is not available for go histogram metrics:

```go
	// There's no `_sum` for histogram, as go metrics only provided buckets and counter of each bucket.
	// See: https://github.com/golang/go/blob/3432c68467d50ffc622fed230a37cd401d82d4bf/src/runtime/metrics/histogram.go#L8
	//
	// Prometheus SDK provides a (under)estimated `_sum` instead.
	// See: https://github.com/prometheus/client_golang/blob/5fe1d33cea76068edd4ece5f58e52f81d225b13c/prometheus/go_collector_latest.go#L498
	//
	// Also, there's no need to provide a `_count` as it can be represented by the `+Inf` bucket.
```