### PR TITLE
lower the log level for failing to get PSI metrics

### DIFF
--- a/process_metrics_linux.go
+++ b/process_metrics_linux.go
@@ -240,7 +240,6 @@ func writeProcessMemMetrics(w io.Writer) {
 	WriteGaugeUint64(w, "process_resident_memory_anon_bytes", ms.rssAnon)
 	WriteGaugeUint64(w, "process_resident_memory_file_bytes", ms.rssFile)
 	WriteGaugeUint64(w, "process_resident_memory_shared_bytes", ms.rssShmem)
-
 }
 
 func getMemStats(path string) (*memStats, error) {
@@ -321,7 +320,7 @@ func psiTotalSecs(microsecs uint64) float64 {
 var psiMetricsStart = func() *psiMetrics {
 	m, err := getPSIMetrics()
 	if err != nil {
-		log.Printf("ERROR: metrics: disable exposing PSI metrics because of failed init: %s", err)
+		log.Printf("INFO: metrics: disable exposing PSI metrics because of failed init: %s", err)
 		return nil
 	}
 	return m


### PR DESCRIPTION
fix https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9161
There are cases where `/proc/self/cgroup` file exists but `/sys/fs/cgroup//cpu.pressure` does not, causing the error log, user cannot fix it. It only causes no data in the PSI related pannels, which should be fine.