### PR TITLE
Add some process metrics for GOOS=darwin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,58 @@
+name: build
+
+on:
+  - push
+  - pull_request
+
+permissions:
+  contents: read
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+jobs:
+  build:
+    name: ${{ matrix.os }}-${{ matrix.arch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: linux
+            arch: 386
+          - os: linux
+            arch: amd64
+          - os: linux
+            arch: arm64
+          - os: linux
+            arch: arm
+          - os: linux
+            arch: ppc64le
+          - os: linux
+            arch: s390x
+          - os: darwin
+            arch: amd64
+          - os: darwin
+            arch: arm64
+          - os: freebsd
+            arch: amd64
+          - os: openbsd
+            arch: amd64
+          - os: windows
+            arch: amd64
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        id: go
+        uses: actions/setup-go@v6
+        with:
+          cache-dependency-path: |
+            go.sum
+          go-version-file: 'go.mod'
+      - run: go version
+
+      - name: Build ${{ matrix.os }}-${{ matrix.arch }}
+        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,31 +1,40 @@
-name: main
+name: test
+
 on:
   - push
   - pull_request
+
+permissions:
+  contents: read
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
 jobs:
-  build:
-    name: Build
+  test:
+    name: test
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: oldstable
-        id: go
       - name: Code checkout
         uses: actions/checkout@v6
+
+      - name: Setup Go
+        id: go
+        uses: actions/setup-go@v6
+        with:
+          cache-dependency-path: |
+            go.sum
+          go-version-file: 'go.mod'
+
+      - run: go version
+
       - name: Test
         run: |
           go test -v ./... -coverprofile=coverage.txt -covermode=atomic
           GOARCH=386 go test ./... -coverprofile=coverage.txt -covermode=atomic
           go test -v ./... -race
-      - name: Build
-        run: |
-          GOOS=linux go build
-          GOOS=darwin go build
-          GOOS=freebsd go build
-          GOOS=windows go build
-          GOARCH=386 go build
+
       - name: Publish coverage
         uses: codecov/codecov-action@v5
         with:

--- a/process_metrics_darwin.go
+++ b/process_metrics_darwin.go
@@ -1,0 +1,153 @@
+//go:build darwin && !ios
+
+package metrics
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"log"
+	"os"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+// errNotImplemented is returned by stub functions that replace cgo functions, when cgo
+// isn't available.
+var errNotImplemented = errors.New("not implemented")
+
+func writeProcessMetrics(w io.Writer) {
+	if memInfo, err := getMemory(); err == nil {
+		WriteGaugeUint64(w, "process_resident_memory_bytes", memInfo.rss)
+		WriteGaugeUint64(w, "process_virtual_memory_bytes", memInfo.vsize)
+	} else if !errors.Is(err, errNotImplemented) {
+		log.Printf("ERROR: metrics: %s", err)
+	}
+
+	// The proc structure returned by kern.proc.pid above has an Rusage member,
+	// but it is not filled in, so it needs to be fetched by getrusage(2).  For
+	// that call, the UTime, STime, and Maxrss members are filled out, but not
+	// Ixrss, Idrss, or Isrss for the memory usage.  Memory stats will require
+	// access to the C API to call task_info(TASK_BASIC_INFO).
+	rusage := syscall.Rusage{}
+
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &rusage); err == nil {
+		cpuTime := time.Duration(rusage.Stime.Nano() + rusage.Utime.Nano()).Seconds()
+		WriteGaugeFloat64(w, "process_cpu_seconds_total", cpuTime)
+	} else {
+		log.Printf("ERROR: metrics: %s", err)
+	}
+
+	if addressSpace, err := getSoftLimit(syscall.RLIMIT_AS); err == nil {
+		WriteGaugeFloat64(w, "process_virtual_memory_max_bytes", float64(addressSpace))
+	} else {
+		log.Printf("ERROR: metrics: %s", err)
+	}
+}
+
+func writeFDMetrics(w io.Writer) {
+	if fds, err := getOpenFileCount(); err == nil {
+		WriteGaugeFloat64(w, "process_open_fds", fds)
+	} else {
+		log.Printf("ERROR: metrics: %s", err)
+	}
+
+	if openFiles, err := getSoftLimit(syscall.RLIMIT_NOFILE); err == nil {
+		WriteGaugeFloat64(w, "process_max_fds", float64(openFiles))
+	} else {
+		log.Printf("ERROR: metrics: %s", err)
+	}
+}
+
+func getOpenFileCount() (float64, error) {
+	// Alternately, the undocumented proc_pidinfo(PROC_PIDLISTFDS) can be used to
+	// return a list of open fds, but that requires a way to call C APIs.  The
+	// benefits, however, include fewer system calls and not failing when at the
+	// open file soft limit.
+
+	if dir, err := os.Open("/dev/fd"); err != nil {
+		return 0.0, err
+	} else {
+		defer dir.Close()
+
+		// Avoid ReadDir(), as it calls stat(2) on each descriptor.  Not only is
+		// that info not used, but KQUEUE descriptors fail stat(2), which causes
+		// the whole method to fail.
+		if names, err := dir.Readdirnames(0); err != nil {
+			return 0.0, err
+		} else {
+			// Subtract 1 to ignore the open /dev/fd descriptor above.
+			return float64(len(names) - 1), nil
+		}
+	}
+}
+
+func getSoftLimit(which int) (uint64, error) {
+	rlimit := syscall.Rlimit{}
+
+	if err := syscall.Getrlimit(which, &rlimit); err != nil {
+		return 0, err
+	}
+
+	return rlimit.Cur, nil
+}
+
+func getProcessStartTime() (float64, error) {
+	// Call sysctl to get kinfo_proc for current process
+	mib := []int32{1 /* CTL_KERN */, 14 /* KERN_PROC */, 1 /* KERN_PROC_PID */, int32(os.Getpid())}
+
+	// First call to get the size
+	n := uintptr(0)
+	_, _, errno := syscall.Syscall6(
+		syscall.SYS___SYSCTL,
+		uintptr(unsafe.Pointer(&mib[0])),
+		uintptr(len(mib)),
+		0,
+		uintptr(unsafe.Pointer(&n)),
+		0,
+		0,
+	)
+	if errno != 0 {
+		return 0, errno
+	}
+	if n == 0 {
+		return 0, syscall.EINVAL
+	}
+
+	// Second call to get the actual data
+	buf := make([]byte, n)
+	_, _, errno = syscall.Syscall6(
+		syscall.SYS___SYSCTL,
+		uintptr(unsafe.Pointer(&mib[0])),
+		uintptr(len(mib)),
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(unsafe.Pointer(&n)),
+		0,
+		0,
+	)
+	if errno != 0 {
+		return 0, errno
+	}
+
+	// The kinfo_proc struct layout on Darwin has p_starttime (struct timeval) at specific offset
+	// For amd64 and arm64, the offset is at 0x60 (96 bytes)
+	// struct timeval has tv_sec (int64) and tv_usec (int32)
+	const startTimeOffset = 0x60
+
+	if len(buf) < startTimeOffset+16 {
+		return 0, syscall.EINVAL
+	}
+
+	// Read tv_sec (8 bytes) and tv_usec (4 bytes)
+	tvSec := int64(binary.LittleEndian.Uint64(buf[startTimeOffset:]))
+	tvUsec := int32(binary.LittleEndian.Uint32(buf[startTimeOffset+8:]))
+
+	startTime := float64(tvSec) + float64(tvUsec)/1e6
+	return startTime, nil
+}
+
+type memoryInfo struct {
+	vsize uint64 // Virtual memory size in bytes
+	rss   uint64 // Resident memory size in bytes
+}

--- a/process_metrics_darwin_cgo.c
+++ b/process_metrics_darwin_cgo.c
@@ -1,0 +1,84 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin && !ios && cgo
+
+#include <mach/mach_init.h>
+#include <mach/task.h>
+#include <mach/mach_vm.h>
+
+// The compiler warns that mach/shared_memory_server.h is deprecated, and to use
+// mach/shared_region.h instead.  But that doesn't define
+// SHARED_DATA_REGION_SIZE or SHARED_TEXT_REGION_SIZE, so redefine them here and
+// avoid a warning message when running tests.
+#define GLOBAL_SHARED_TEXT_SEGMENT      0x90000000U
+#define SHARED_DATA_REGION_SIZE         0x10000000
+#define SHARED_TEXT_REGION_SIZE         0x10000000
+
+
+int get_memory_info(unsigned long long *rss, unsigned long long *vsize)
+{
+    // This is lightly adapted from how ps(1) obtains its memory info.
+    // https://github.com/apple-oss-distributions/adv_cmds/blob/8744084ea0ff41ca4bb96b0f9c22407d0e48e9b7/ps/tasks.c#L109
+
+    kern_return_t               error;
+    task_t                      task = MACH_PORT_NULL;
+    mach_task_basic_info_data_t info;
+    mach_msg_type_number_t      info_count = MACH_TASK_BASIC_INFO_COUNT;
+
+    error = task_info(
+                mach_task_self(),
+                MACH_TASK_BASIC_INFO,
+                (task_info_t) &info,
+                &info_count );
+
+    if( error != KERN_SUCCESS )
+    {
+        return error;
+    }
+
+    *rss   = info.resident_size;
+    *vsize = info.virtual_size;
+
+    {
+        vm_region_basic_info_data_64_t    b_info;
+        mach_vm_address_t                 address = GLOBAL_SHARED_TEXT_SEGMENT;
+        mach_vm_size_t                    size;
+        mach_port_t                       object_name;
+
+        /*
+         * try to determine if this task has the split libraries
+         * mapped in... if so, adjust its virtual size down by
+         * the 2 segments that are used for split libraries
+         */
+        info_count = VM_REGION_BASIC_INFO_COUNT_64;
+
+        error = mach_vm_region(
+                    mach_task_self(),
+                    &address,
+                    &size,
+                    VM_REGION_BASIC_INFO_64,
+                    (vm_region_info_t) &b_info,
+                    &info_count,
+                    &object_name);
+
+        if (error == KERN_SUCCESS) {
+            if (b_info.reserved && size == (SHARED_TEXT_REGION_SIZE) &&
+                *vsize > (SHARED_TEXT_REGION_SIZE + SHARED_DATA_REGION_SIZE)) {
+                    *vsize -= (SHARED_TEXT_REGION_SIZE + SHARED_DATA_REGION_SIZE);
+            }
+        }
+    }
+
+    return 0;
+}

--- a/process_metrics_darwin_cgo.go
+++ b/process_metrics_darwin_cgo.go
@@ -1,0 +1,22 @@
+//go:build darwin && !ios && cgo
+
+package metrics
+
+/*
+int get_memory_info(unsigned long long *rss, unsigned long long *vs);
+*/
+import "C"
+
+import (
+	"fmt"
+)
+
+func getMemory() (*memoryInfo, error) {
+	var rss, vsize C.ulonglong
+
+	if err := C.get_memory_info(&rss, &vsize); err != 0 {
+		return nil, fmt.Errorf("task_info() failed with 0x%x", int(err))
+	}
+
+	return &memoryInfo{vsize: uint64(vsize), rss: uint64(rss)}, nil
+}

--- a/process_metrics_darwin_nocgo.go
+++ b/process_metrics_darwin_nocgo.go
@@ -1,0 +1,7 @@
+//go:build darwin && !ios && !cgo
+
+package metrics
+
+func getMemory() (*memoryInfo, error) {
+	return nil, errNotImplemented
+}

--- a/process_metrics_other.go
+++ b/process_metrics_other.go
@@ -1,4 +1,4 @@
-//go:build !linux && !windows && !solaris
+//go:build !linux && !windows && !solaris && !darwin
 
 package metrics
 


### PR DESCRIPTION
Adds support for process metrics on MacOS\Darwin. I added only those that do not require CGO. 
- ~~process_start_time_seconds~~
- process_cpu_seconds_total
- process_virtual_memory_max_bytes
- process_virtual_memory_bytes
- process_resident_memory_bytes
- process_open_fds
- process_max_fds

Fixes https://github.com/VictoriaMetrics/metrics/issues/75

Inspired by https://github.com/prometheus/client_golang/blob/main/prometheus/process_collector_darwin.go