### PR TITLE
perf: pool bytes.Buffer in WritePrometheus to reduce allocations

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -13,6 +13,7 @@
 package metrics
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"sort"
@@ -42,6 +43,11 @@ func init() {
 var (
 	registeredSets     = make(map[*Set]struct{})
 	registeredSetsLock sync.Mutex
+	bufPool            = sync.Pool{
+		New: func() any {
+			return bytes.NewBuffer(make([]byte, 0, 64*1024))
+		},
+	}
 )
 
 // RegisterSet registers the given set s for metrics export via global WritePrometheus() call.

--- a/set.go
+++ b/set.go
@@ -35,7 +35,10 @@ func NewSet() *Set {
 // WritePrometheus writes all the metrics from s to w in Prometheus format.
 func (s *Set) WritePrometheus(w io.Writer) {
 	// Collect all the metrics in in-memory buffer in order to prevent from long locking due to slow w.
-	var bb bytes.Buffer
+	bb := bufPool.Get().(*bytes.Buffer)
+	bb.Reset()
+	defer bufPool.Put(bb)
+
 	lessFunc := func(i, j int) bool {
 		// the sorting must be stable.
 		// see edge cases why we can't simply do `s.a[i].name < s.a[j].name` here:
@@ -77,7 +80,7 @@ func (s *Set) WritePrometheus(w io.Writer) {
 		if !isMetadataEnabled() {
 			// Call marshalTo without the global lock, since certain metric types such as Gauge
 			// can call a callback, which, in turn, can try calling s.mu.Lock again.
-			nm.metric.marshalTo(nm.name, &bb)
+			nm.metric.marshalTo(nm.name, bb)
 			continue
 		}
 
@@ -93,7 +96,7 @@ func (s *Set) WritePrometheus(w io.Writer) {
 		if metricFamily != prevMetricFamily {
 			// write metadata only once per metric family
 			metricType := nm.metric.metricType()
-			writeMetadata(&bb, metricFamily, metricType)
+			writeMetadata(bb, metricFamily, metricType)
 			prevMetricFamily = metricFamily
 		}
 		bb.Write(metricsWithMetadataBuf.Bytes())


### PR DESCRIPTION
Use sync.Pool to reuse bytes.Buffer in (*Set).WritePrometheus, eliminating repeated bytes.growSlice allocations.

Production pprof shows alloc_space dropped by 98.6% (12,380 MB → 170 MB) and alloc_objects dropped by 96.6% (71.6M → 2.5M).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pool a reusable `bytes.Buffer` in `WritePrometheus` to cut allocations and GC pressure. In production pprof, alloc_space dropped 98.6% (12,380 MB → 170 MB) and alloc_objects 96.6% (71.6M → 2.5M).

- **Refactors**
  - Add a `sync.Pool` that returns a pre-sized `bytes.Buffer` (64 KiB cap).
  - Use the pooled buffer in `(*Set).WritePrometheus`, resetting and returning it to the pool to avoid repeated `bytes.growSlice` allocations.

<sup>Written for commit ed6e57aef5b831902e48dc08152bcf091fee34a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

