### PR TITLE
feat: export WriteGoMetrics, WriteProcMetrics and WritePushMetrics fo…

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -248,6 +248,23 @@ func WriteProcessMetrics(w io.Writer) {
 	writePushMetrics(w)
 }
 
+// WriteGoMetrics writes Go runtime metrics to w.
+// This includes runtime/metrics such as memory stats, GC stats, goroutine counts, etc.
+func WriteGoMetrics(w io.Writer) {
+	writeGoMetrics(w)
+}
+
+// WriteProcMetrics writes OS-level process metrics to w by reading
+// the /proc filesystem (CPU, memory, file descriptors, PSI, etc.).
+func WriteProcMetrics(w io.Writer) {
+	writeProcessMetrics(w)
+}
+
+// WritePushMetrics writes push-mode related metrics to w.
+func WritePushMetrics(w io.Writer) {
+	writePushMetrics(w)
+}
+
 // WriteFDMetrics writes `process_max_fds` and `process_open_fds` metrics to w.
 func WriteFDMetrics(w io.Writer) {
 	writeFDMetrics(w)


### PR DESCRIPTION
feat: export WriteGoMetrics, WriteProcMetrics and WritePushMetrics for selective metrics collection

Previously, WriteProcessMetrics bundled Go runtime metrics, /proc filesystem
metrics and push-mode metrics into a single call with no way to opt out.

This commit exports the three internal functions as public APIs, allowing users
to selectively collect only the metrics they need while keeping
WriteProcessMetrics unchanged for backward compatibility.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exported WriteGoMetrics, WriteProcMetrics, and WritePushMetrics so callers can collect only the metrics they need. WriteProcessMetrics remains unchanged for backward compatibility and still writes all three.

<sup>Written for commit 30cd75ce437204dfe98c4442e938d584e8b82249. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

