### PR TITLE
fix metrics type metadata when some quantiles are cleaned due to summary window

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -26,7 +26,11 @@ import (
 type namedMetric struct {
 	name   string
 	metric metric
-	isAux  bool
+
+	// isAux indicates whether it is an auxiliary metric.
+	// Currently only set for quantileValue, as it is part of the Summary.
+	// This field affects sorting when quantileValue and Summary are compared.
+	isAux bool
 }
 
 type metric interface {

--- a/set.go
+++ b/set.go
@@ -50,12 +50,10 @@ func (s *Set) WritePrometheus(w io.Writer) {
 			return fName1 < fName2
 		}
 
-		// Only summary and quantile(s) have different metric types.
-		// Sorting by metric type will stabilize the order for summary and quantile(s).
-		mType1 := s.a[i].metric.metricType()
-		mType2 := s.a[j].metric.metricType()
-		if mType1 != mType2 {
-			return mType1 < mType2
+		// if both has same family, check the auxiliary first.
+		// only summary quantile(s) is registered as auxiliary, and quantile(s) in summary should go first.
+		if s.a[i].isAux != s.a[j].isAux {
+			return s.a[i].isAux
 		}
 
 		// lastly by metric names, which is for quantiles and histogram buckets.

--- a/set_example_test.go
+++ b/set_example_test.go
@@ -3,6 +3,7 @@ package metrics_test
 import (
 	"bytes"
 	"fmt"
+	"time"
 
 	"github.com/VictoriaMetrics/metrics"
 )
@@ -54,6 +55,11 @@ func ExampleExposeMetadata() {
 	// This summary will have quantiles printed before _sum/_count metrics
 	s.NewSummary(`vm_request_duration_seconds{path="/api/v1/query_range"}`).Update(1)
 
+	var testSummaryQuantilesNoop = []float64{0.5, 0.9, 0.97, 0.99, 1}
+	testWindow := 50 * time.Millisecond
+	s.NewSummaryExt(`test_summary_expire_quick`, testWindow, testSummaryQuantilesNoop).Update(1)
+	time.Sleep(4 * testWindow)
+
 	// Dump metrics from s.
 	var bb bytes.Buffer
 	s.WritePrometheus(&bb)
@@ -88,6 +94,10 @@ func ExampleExposeMetadata() {
 	// # HELP set_counter
 	// # TYPE set_counter counter
 	// set_counter 1
+	// # HELP test_summary_expire_quick
+	// # TYPE test_summary_expire_quick summary
+	// test_summary_expire_quick_sum 1
+	// test_summary_expire_quick_count 1
 	// # HELP unused_bytes
 	// # TYPE unused_bytes gauge
 	// unused_bytes{foo="bar"} 58

--- a/set_example_test.go
+++ b/set_example_test.go
@@ -3,7 +3,6 @@ package metrics_test
 import (
 	"bytes"
 	"fmt"
-	"time"
 
 	"github.com/VictoriaMetrics/metrics"
 )
@@ -55,11 +54,6 @@ func ExampleExposeMetadata() {
 	// This summary will have quantiles printed before _sum/_count metrics
 	s.NewSummary(`vm_request_duration_seconds{path="/api/v1/query_range"}`).Update(1)
 
-	var testSummaryQuantilesNoop = []float64{0.5, 0.9, 0.97, 0.99, 1}
-	testWindow := 50 * time.Millisecond
-	s.NewSummaryExt(`test_summary_expire_quick`, testWindow, testSummaryQuantilesNoop).Update(1)
-	time.Sleep(4 * testWindow)
-
 	// Dump metrics from s.
 	var bb bytes.Buffer
 	s.WritePrometheus(&bb)
@@ -94,10 +88,6 @@ func ExampleExposeMetadata() {
 	// # HELP set_counter
 	// # TYPE set_counter counter
 	// set_counter 1
-	// # HELP test_summary_expire_quick
-	// # TYPE test_summary_expire_quick summary
-	// test_summary_expire_quick_sum 1
-	// test_summary_expire_quick_count 1
 	// # HELP unused_bytes
 	// # TYPE unused_bytes gauge
 	// unused_bytes{foo="bar"} 58

--- a/set_test.go
+++ b/set_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"bytes"
 	"fmt"
 	"sync"
 	"testing"
@@ -170,4 +171,28 @@ func TestRegisterUnregister(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+func TestMetadataForAfterSummaryWindow(t *testing.T) {
+	ExposeMetadata(true)
+	defer ExposeMetadata(false)
+
+	s := NewSet()
+	var testSummaryQuantilesNoop = []float64{0.5, 0.9, 0.97, 0.99, 1}
+	testWindow := 50 * time.Millisecond
+	s.NewSummaryExt(`test_summary_expire_quick`, testWindow, testSummaryQuantilesNoop).Update(1)
+	time.Sleep(4 * testWindow)
+
+	var bb bytes.Buffer
+	s.WritePrometheus(&bb)
+
+	expect := `# HELP test_summary_expire_quick
+# TYPE test_summary_expire_quick summary
+test_summary_expire_quick_sum 1
+test_summary_expire_quick_count 1
+`
+
+	if bb.String() != expect {
+		t.Fatalf("unexpected summary metric names:\n%s", bb.String())
+	}
 }

--- a/summary.go
+++ b/summary.go
@@ -120,13 +120,7 @@ func (sm *Summary) marshalTo(prefix string, w io.Writer) {
 }
 
 func (sm *Summary) metricType() string {
-	// this metric type should not be printed, because summary (sum and count)
-	// of the same metric family will be printed after quantile(s).
-	// If metadata is needed, the metadata from quantile(s) should be used.
-	// quantile will be printed first, so its metrics type won't be printed as metadata.
-	// Printing quantiles before sum and count aligns this code with Prometheus behavior.
-	// See: https://github.com/VictoriaMetrics/metrics/pull/99
-	return "unsupported"
+	return "summary"
 }
 
 func splitMetricName(name string) (string, string) {


### PR DESCRIPTION
fix https://github.com/VictoriaMetrics/metrics/issues/120

For summary data, it contains `*Summary` and multiple `*quantileValue`. When printing, they'll be sorted by their `metricType`:
1. `*Summary` has `unsupported`.
2. `*quantileValue` has `summary`.

So `*quantileValue` are always printed first.

However, the  `*quantileValue` could be removed if stale for 5 minutes, in this case, the `metricType` of `*Summary` will be printed (as `unsupported`), while the expectation would be `summary`.

This pull request specific the metric type for both to `summary` and sort them by `isAux`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TYPE metadata for summary metrics when quantiles expire. Always emits TYPE summary and sorts quantiles before _sum/_count using an auxiliary flag, not metric-type sorting.

- **Bug Fixes**
  - Set `Summary.metricType()` to return "summary" so metadata stays correct even if only _sum/_count remain.
  - Use `isAux` to sort quantiles before _sum/_count within the same family; remove metric-type-based sorting.
  - Add a unit test for a short-window `SummaryExt` to verify TYPE summary after quantiles expire; add an `isAux` comment to clarify the sorting behavior.

<sup>Written for commit ef2c19af469953d3206e066931a82da5c76f8466. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



