### PR TITLE
fix: place 1e18 in the top regular histogram bucket

### DIFF
--- a/histogram.go
+++ b/histogram.go
@@ -18,6 +18,10 @@ const (
 
 var bucketMultiplier = math.Pow(10, 1.0/bucketsPerDecimal)
 
+// maxRegularBucketValue is the upper bound of the last regular bucket (1e18).
+// Values greater than it belong to the +Inf overflow bucket.
+var maxRegularBucketValue = math.Pow10(e10Max)
+
 // Histogram is a histogram for non-negative values with automatically created buckets.
 //
 // See https://medium.com/@valyala/improving-histogram-usability-for-prometheus-and-grafana-bc7e5df0e350
@@ -95,7 +99,11 @@ func (h *Histogram) Update(v float64) {
 	h.sum += v
 	if bucketIdx < 0 {
 		h.lower++
-	} else if bucketIdx >= bucketsCount {
+	} else if bucketIdx > bucketsCount || v > maxRegularBucketValue {
+		// The value check guards against float rounding: for values slightly
+		// above 1e18, math.Log10 still returns exactly 18, so bucketIdx == 486
+		// and the bucketIdx check alone would let them fall into the last
+		// regular bucket instead of the +Inf overflow bucket.
 		h.upper++
 	} else {
 		idx := uint(bucketIdx)

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -139,6 +139,32 @@ prefix_count 120
 	}
 }
 
+func TestHistogramMaxPowerOfTenBoundary(t *testing.T) {
+	// The maximum exact power of ten (1e18) must land in the top regular
+	// bucket, whose inclusive upper bound is 1e18 - consistent with how the
+	// other 10^n values are placed. Only values strictly greater than 1e18
+	// belong in the +Inf overflow bucket.
+	f := func(v float64, want string) {
+		t.Helper()
+		h := &Histogram{}
+		h.Update(v)
+		got := ""
+		h.VisitNonZeroBuckets(func(vmrange string, _ uint64) {
+			got = vmrange
+		})
+		if got != want {
+			t.Errorf("Update(%g) landed in %q; want %q", v, got, want)
+		}
+	}
+	f(1e18, "8.799e+17...1.000e+18")
+	f(9.999e17, "8.799e+17...1.000e+18")
+	f(1.0001e18, "1.000e+18...+Inf")
+	f(math.Inf(1), "1.000e+18...+Inf")
+	// Values just above 1e18 still have math.Log10 == 18 (so bucketIdx == 486),
+	// but must land in the +Inf overflow bucket, not the last regular bucket.
+	f(math.Nextafter(1e18, math.Inf(1)), "1.000e+18...+Inf")
+}
+
 func TestHistogramConcurrent(t *testing.T) {
 	name := "HistogramConcurrent"
 	h := NewHistogram(name)


### PR DESCRIPTION
Fixes #130.

## Bug

`Histogram.Update` misclassifies exactly `1e18` into the `+Inf` overflow bucket instead of the top regular bucket.

```go
h := &metrics.Histogram{}
h.Update(1e18)
h.VisitNonZeroBuckets(func(vmrange string, _ uint64) { fmt.Println(vmrange) })
// prints: 1.000e+18...+Inf     (wrong)
// want:   8.799e+17...1.000e+18
```

## Root cause

`bucketIdx = (log10(v) - e10Min) * bucketsPerDecimal`. With `e10Min = -9`, `bucketsPerDecimal = 18` and `bucketsCount = 486`, the value `1e18` gives `bucketIdx = (18 - (-9)) * 18 = 486`, exactly equal to `bucketsCount`. The overflow guard used `>=`:

```go
} else if bucketIdx >= bucketsCount {
    h.upper++
```

so `1e18` was routed to `+Inf` before reaching the regular-bucket path — which already contains the `10^n` edge case (`idx--`) that places a power of ten in the bucket whose **inclusive** upper bound is that power of ten. Every interior `10^n` (e.g. `100 → 8.799e+01...1.000e+02`) is placed correctly; only the maximum, `1e18`, was intercepted by the `>=` guard.

## Fix

Use `>` so only values **strictly greater** than `1e18` overflow:

```go
} else if bucketIdx > bucketsCount {
    h.upper++
```

`1e18` (the only value with `bucketIdx == 486`) now falls through to the regular path, where the existing `10^n` edge case decrements `idx` to `485` — the `8.799e+17...1.000e+18` bucket. `math.Inf(1)` and any value above `1e18` still produce `bucketIdx > 486` and remain in `+Inf`.

## Testing

Added `TestHistogramMaxPowerOfTenBoundary` asserting `1e18` and `9.999e17` land in `8.799e+17...1.000e+18`, while `1.0001e18` and `math.Inf(1)` remain in `1.000e+18...+Inf`. It fails on the current code and passes with the fix. The full package test suite (including `-race`) passes unchanged.
