### PR TITLE
tests: format histogram code labels as quoted integers

### DIFF
--- a/histogram_example_test.go
+++ b/histogram_example_test.go
@@ -20,7 +20,7 @@ func ExampleHistogram() {
 func ExampleHistogram_vec() {
 	for i := range 3 {
 		// Dynamically construct metric name and pass it to GetOrCreateHistogram.
-		name := fmt.Sprintf(`response_size_bytes{path=%q, code=%q}`, "/foo/bar", 200+i)
+		name := fmt.Sprintf(`response_size_bytes{path=%q, code="%d"}`, "/foo/bar", 200+i)
 		response := processRequest()
 		metrics.GetOrCreateHistogram(name).Update(float64(len(response)))
 	}

--- a/prometheus_histogram_example_test.go
+++ b/prometheus_histogram_example_test.go
@@ -20,7 +20,7 @@ func ExamplePrometheusHistogram() {
 func ExamplePrometheusHistogram_vec() {
 	for i := range 3 {
 		// Dynamically construct metric name and pass it to GetOrCreatePrometheusHistogram.
-		name := fmt.Sprintf(`response_size_bytes{path=%q, code=%q}`, "/foo/bar", 200+i)
+		name := fmt.Sprintf(`response_size_bytes{path=%q, code="%d"}`, "/foo/bar", 200+i)
 		response := processRequest()
 		metrics.GetOrCreatePrometheusHistogram(name).Update(float64(len(response)))
 	}


### PR DESCRIPTION
Format the integer status code with `%d` and add the required Prometheus label quotes explicitly. The current `%q` directive is invalid for integers and causes current Go vet checks to fail.

Tested with `go test ./...`.